### PR TITLE
Update standard-http-error@2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3627,9 +3627,9 @@
       "integrity": "sha1-I+UWj6HAggGJ5YEnAaeQWFENDTQ="
     },
     "standard-http-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/standard-http-error/-/standard-http-error-2.0.0.tgz",
-      "integrity": "sha1-tZKVwT9n//pLeJc/LlItwUJrPfU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/standard-http-error/-/standard-http-error-2.0.1.tgz",
+      "integrity": "sha1-+K6RcuPO+cs40ucIShkl9Xp8NL0=",
       "requires": {
         "standard-error": "1.1.0"
       }
@@ -3639,15 +3639,6 @@
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "string-length": {
       "version": "1.0.1",
@@ -3667,6 +3658,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint-staged"
   ],
   "dependencies": {
-    "standard-http-error": "^2.0.0"
+    "standard-http-error": "^2.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2565,9 +2565,9 @@ staged-git-files@0.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/standard-error/-/standard-error-1.1.0.tgz#23e5168fa1c0820189e5812701a79058510d0d34"
 
-standard-http-error@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/standard-http-error/-/standard-http-error-2.0.0.tgz#b59295c13f67fffa4b78973f2e522dc1426b3df5"
+standard-http-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-http-error/-/standard-http-error-2.0.1.tgz#f8ae9172e3cef9cb38d2e7084a1925f57a7c34bd"
   dependencies:
     standard-error ">= 1.1.0 < 2"
 


### PR DESCRIPTION
This PR updates `standard-http-error` dependency to version `v2.0.1`.