### PR TITLE
Drop node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "4.2.0"
   - "6.0.0"
   - "8.0.0"
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pre-commit": "^1.2.2"
   },
   "engines": {
-    "node": ">=4.2"
+    "node": ">=6"
   },
   "jest": {
     "coverageDirectory": "coverage",


### PR DESCRIPTION
This PR updates node engines and travis config to drop node 4 support.